### PR TITLE
Remove hard-coded PKG_CONFIG_PATH

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,17 +1,6 @@
 {
 	"variables": {
-		"GTK_Root%": "c:\\gtk",
-		"conditions": [
-			[
-				"OS == 'mac'",
-				{
-					"pkg_env": "PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig"
-				},
-				{
-					"pkg_env": ""
-				}
-			]
-		]
+		"GTK_Root%": "c:\\gtk"
 	},
 	"targets": [
 		{
@@ -30,9 +19,9 @@
 					[
 						"OS!='win'",
 						{
-							"libraries": "<!(<(pkg_env) pkg-config --libs-only-l <(packages))",
-							"ldflags": "<!(<(pkg_env) pkg-config --libs-only-L --libs-only-other <(packages))",
-							"cflags": "<!(<(pkg_env) pkg-config --cflags <(packages))"
+							"libraries": "<!(pkg-config --libs-only-l <(packages))",
+							"ldflags": "<!(pkg-config --libs-only-L --libs-only-other <(packages))",
+							"cflags": "<!(pkg-config --cflags <(packages))"
 						},
 						{
 							"include_dirs": "<!(<(python) tools/include_dirs.py <(GTK_Root) <(packages))"


### PR DESCRIPTION
This is preventing me from building on macOS 10.14.4, because it overwrites any other PKG_CONFIG_PATH that I have set in my environment.

On my system, which I've set up using what I believe to be just standard Homebrew, I don't need to have `/opt/X11/lib/pkgconfig` in my pkg config path. I do however need to have `/usr/local/opt/libffi/lib/pkgconfig` in there, which I had but it was overwritten by the removed lines.

I'm not sure why this line was added in the beginning ([it was a long time ago in a fork](https://github.com/f3lang/node-rsvg-prebuilt/commit/08e49185be38e6a85f1441cfdb1df60aa9562b13)), but I think that it's up to the end user to have a correctly configured pkg config installation. Trying to fix end user configuration errors is error-prone and can easily lead to more errors (as seen here ☺️)...