### PR TITLE
Add libffi from Homebrew pkg config path

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,7 @@
 			[
 				"OS == 'mac'",
 				{
-					"pkg_env": "PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig"
+					"pkg_env": "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/opt/X11/lib/pkgconfig"
 				},
 				{
 					"pkg_env": ""

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,7 @@
 			[
 				"OS == 'mac'",
 				{
-					"pkg_env": "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/opt/X11/lib/pkgconfig"
+					"pkg_env": "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/opt/X11/lib/pkgconfig:/usr/local/opt/libffi/lib/pkgconfig"
 				},
 				{
 					"pkg_env": ""


### PR DESCRIPTION
I think I would prefer it if #12 was merged instead of this, but if you want to continue to help users with a "misconfigured" pkg-config this should preserve the upstream and append directories instead of replacing it.

It also adds the directory to `libffi` which is "keg only" by default in Homebrew.